### PR TITLE
Enhance SEO metadata with Open Graph and Twitter tags across the site

### DIFF
--- a/app/app.vue
+++ b/app/app.vue
@@ -1,3 +1,11 @@
+<script setup lang="ts">
+useSeoMeta({
+  ogSiteName: 'CodeBlogNL',
+  ogLocale: 'nl_NL',
+  twitterCard: 'summary_large_image',
+})
+</script>
+
 <template>
   <UApp>
     <NuxtLayout>

--- a/app/pages/blog/[slug].vue
+++ b/app/pages/blog/[slug].vue
@@ -66,7 +66,18 @@ const { data: author } = await useAsyncData(`author-${doc.value?.author}`, () =>
 if (doc.value) {
   useSeoMeta({
     title: `${doc.value.title} - CodeBlog.nl`,
-    description: doc.value.description
+    description: doc.value.description,
+
+    ogTitle: `${doc.value.title} - CodeBlog.nl`,
+    ogDescription: doc.value.description,
+    ogType: 'article',
+    ogUrl: `https://codeblog.nl/blog/${doc.value.slug}`,
+
+    articleAuthor: author.value?.name || doc.value.author,
+    articlePublishedTime: doc.value.date,
+
+    twitterTitle: `${doc.value.title} - CodeBlog.nl`,
+    twitterDescription: doc.value.description,
   })
 
   defineOgImageComponent('BlogArticle', {
@@ -74,7 +85,7 @@ if (doc.value) {
     description: doc.value.description,
     authorName: author.value?.name || doc.value.author,
     authorImage: author.value?.image,
-    alt: `Social media afbeelding voor het artikel: ${doc.value.title}`
+    alt: `Social media afbeelding voor het artikel: ${doc.value.title}`,
   })
 }
 

--- a/app/pages/blog/index.vue
+++ b/app/pages/blog/index.vue
@@ -27,8 +27,25 @@
 const { posts } = useBlogPosts()
 
 useSeoMeta({
-  title: 'Blog - CodeBlog.nl',
-  description: 'Lees de nieuwste artikelen over .NET, Azure, VueJS en moderne software ontwikkeling.'
+  title: 'Blog overzicht - CodeBlog.nl',
+  description: 'Lees de nieuwste artikelen over .NET, Azure, VueJS en moderne softwareontwikkeling.',
+
+  ogTitle: 'Blog overzicht - CodeBlog.nl',
+  ogDescription: 'Lees de nieuwste artikelen over .NET, Azure, VueJS en moderne softwareontwikkeling.',
+  ogType: 'website',
+  ogUrl: 'https://codeblog.nl/blog',
+  ogSiteName: 'CodeBlog.nl',
+  ogLocale: 'nl_NL',
+  ogImage: 'https://codeblog.nl/og/blog.png',
+  ogImageWidth: 1200,
+  ogImageHeight: 630,
+  ogImageAlt: 'Blog overzicht - CodeBlog.nl',
+
+  twitterCard: 'summary_large_image',
+  twitterTitle: 'Blog overzicht - CodeBlog.nl',
+  twitterDescription: 'Lees de nieuwste artikelen over .NET, Azure, VueJS en moderne softwareontwikkeling.',
+  twitterImage: 'https://codeblog.nl/og/blog.png',
+  twitterImageAlt: 'Blog overzicht - CodeBlog.nl',
 })
 
 defineOgImageComponent('General', {

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -79,7 +79,24 @@ const { recentPosts } = useBlogPosts()
 
 useSeoMeta({
   title: 'CodeBlog.nl - .NET, C#, Azure en VueJS voor Nederlandstalige Developers',
-  description: 'CodeBlog.nl is hét platform voor Nederlandstalige developers over .NET, C#, Azure, VueJS and moderne software engineering.'
+  description: 'CodeBlog.nl is hét platform voor Nederlandstalige developers over .NET, C#, Azure, VueJS en moderne software engineering.',
+
+  ogTitle: 'CodeBlog.nl - .NET, C#, Azure en VueJS voor Nederlandstalige Developers',
+  ogDescription: 'CodeBlog.nl is hét platform voor Nederlandstalige developers over .NET, C#, Azure, VueJS en moderne software engineering.',
+  ogType: 'website',
+  ogUrl: 'https://codeblog.nl/',
+  ogSiteName: 'CodeBlog.nl',
+  ogLocale: 'nl_NL',
+  ogImage: 'https://codeblog.nl/og/home.png',
+  ogImageWidth: 1200,
+  ogImageHeight: 630,
+  ogImageAlt: 'CodeBlog.nl - Nederlandstalige blog over .NET, C#, Azure en VueJS',
+
+  twitterCard: 'summary_large_image',
+  twitterTitle: 'CodeBlog.nl - .NET, C#, Azure en VueJS voor Nederlandstalige Developers',
+  twitterDescription: 'CodeBlog.nl is hét platform voor Nederlandstalige developers over .NET, C#, Azure, VueJS en moderne software engineering.',
+  twitterImage: 'https://codeblog.nl/og/home.png',
+  twitterImageAlt: 'CodeBlog.nl - Nederlandstalige blog over .NET, C#, Azure en VueJS',
 })
 
 defineOgImageComponent('General', {

--- a/app/pages/over.vue
+++ b/app/pages/over.vue
@@ -50,7 +50,24 @@
 <script setup lang="ts">
 useSeoMeta({
   title: 'Over ons - CodeBlog.nl',
-  description: 'Leer meer over de missie en visie van CodeBlog.nl, hét platform voor Nederlandstalige developers.'
+  description: 'Leer meer over de missie en visie van CodeBlog.nl, hét platform voor Nederlandstalige developers.',
+
+  ogTitle: 'Over ons - CodeBlog.nl',
+  ogDescription: 'Leer meer over de missie en visie van CodeBlog.nl, hét platform voor Nederlandstalige developers.',
+  ogType: 'website',
+  ogUrl: 'https://codeblog.nl/over-ons',
+  ogSiteName: 'CodeBlog.nl',
+  ogLocale: 'nl_NL',
+  ogImage: 'https://codeblog.nl/og/over-ons.png',
+  ogImageWidth: 1200,
+  ogImageHeight: 630,
+  ogImageAlt: 'Over ons - CodeBlog.nl',
+
+  twitterCard: 'summary_large_image',
+  twitterTitle: 'Over ons - CodeBlog.nl',
+  twitterDescription: 'Leer meer over de missie en visie van CodeBlog.nl, hét platform voor Nederlandstalige developers.',
+  twitterImage: 'https://codeblog.nl/og/over-ons.png',
+  twitterImageAlt: 'Over ons - CodeBlog.nl',
 })
 
 defineOgImageComponent('General', {

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -10,7 +10,7 @@ export default defineNuxtConfig({
   },
   site: {
     url: 'https://codeblog.nl',
-    name: 'CodeBlogNL'
+    name: 'CodeBlog.nl'
   },
   css: ['~/assets/css/main.css'],
   compatibilityDate: '2025-07-15',
@@ -22,6 +22,9 @@ export default defineNuxtConfig({
       },
       link: [
         { rel: 'icon', type: 'image/x-icon', href: '/favicon.ico' }
+      ],
+      meta: [
+        { name: 'apple-mobile-web-app-title', content: 'CodeBlog.nl' },
       ]
     }
   },


### PR DESCRIPTION
This pull request adds comprehensive Open Graph and Twitter meta tags to all main pages of the site to improve SEO and social media sharing. It also standardizes the site name to "CodeBlog.nl" and adds an Apple web app title. The most important changes are grouped below.

**SEO and Social Media Meta Improvements**

* Added detailed Open Graph and Twitter meta tags to the homepage (`index.vue`), blog overview (`blog/index.vue`), blog articles (`blog/[slug].vue`), and the about page (`over.vue`) for enhanced SEO and better appearance when sharing links on social platforms. These include title, description, image, locale, and card type fields. [[1]](diffhunk://#diff-16d9afef3e4c9ffca1d5f4d2ae7be326ec3da168945ef08912e0563bc908c7b5L82-R99) [[2]](diffhunk://#diff-5385ef7432b85023c447818e699f06a16aa5f9fcbcb1bfbf586cadccafbdbb80L30-R48) [app/pages/blog/[slug].vueL69-R88](diffhunk://#diff-0ad48f0325d26c0c92819e15717793d542e221a11b3ad48fb07aef7bbe3e9a59L69-R88), [[3]](diffhunk://#diff-b5289412da2af5f3b02b0904b3966476cd752eddc21798e1c3563f6f14f2cab2L53-R70)
* Set default Open Graph and Twitter meta tags at the app level in `app.vue` for consistent social sharing defaults.

**Site Branding and Metadata**

* Standardized the site name from "CodeBlogNL" to "CodeBlog.nl" in the Nuxt configuration and meta tags.
* Added an Apple mobile web app title meta tag for better branding on iOS devices.