### PR TITLE
Add markdown linting configuration and GitHub Action

### DIFF
--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -1,0 +1,31 @@
+name: Markdown Linting
+
+on:
+  pull_request:
+    paths:
+      - '**/*.md'
+      - '**/*.mdx'
+      - '.markdownlint.json'
+      - 'package.json'
+      - 'package-lock.json'
+
+env:
+  NODE_VERSION: '24.x'
+
+jobs:
+  markdown-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node.js version
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Run markdown lint
+        run: npm run lint:md

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,5 @@
+{
+  "default": true,
+  "MD013": false,
+  "MD033": false
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,8 +6,8 @@ Bedankt dat je wilt bijdragen! We hebben het proces zo eenvoudig mogelijk gemaak
 
 Artikelen staan in de map `content/blog/`. Volg deze stappen om een nieuw artikel toe te voegen:
 
-1.  **Maak een nieuw Markdown-bestand**: Maak een bestand aan in `content/blog/` met de naam `jouw-artikel-titel.md`.
-2.  **Voeg Frontmatter toe**: Elk artikel begint met een blok tekst tussen `---`. Dit bevat de metadata:
+1. **Maak een nieuw Markdown-bestand**: Maak een bestand aan in `content/blog/` met de naam `jouw-artikel-titel.md`.
+2. **Voeg Frontmatter toe**: Elk artikel begint met een blok tekst tussen `---`. Dit bevat de metadata:
 
     ```markdown
     ---
@@ -22,14 +22,15 @@ Artikelen staan in de map `content/blog/`. Volg deze stappen om een nieuw artike
     Je kan hier alle markdown dingen (koppen, codeblokken, links, etc.) gebruiken.
     ```
 
-3.  **Koppel een auteur**: Gebruik de exact dezelfde naam als in je auteursbestand (`content/authors/JouwNaam.json`) bij de `author` property in de frontmatter.
+3. **Koppel een auteur**: Gebruik de exact dezelfde naam als in je auteursbestand (`content/authors/JouwNaam.json`) bij de `author` property in de frontmatter.
 
 ## Hoe voeg ik een auteur toe?
 
 Als dit je eerste artikel is, voeg jezelf dan toe als auteur:
 
-1.  **Maak een nieuw JSON-bestand**: Maak een bestand aan in `content/authors/` met de naam `VoornaamAchternaam.json` (bijv. `LouellaCreemers.json`).
-2.  **Voeg je gegevens toe**: Gebruik de volgende structuur:
+1. **Maak een nieuw JSON-bestand**: Maak een bestand aan in `content/authors/` met de naam `VoornaamAchternaam.json` (bijv. `LouellaCreemers.json`).
+2. **Voeg je gegevens toe**: Gebruik de volgende structuur:
+
     ```json
     {
       "name": "Jouw Volledige Naam",
@@ -38,7 +39,8 @@ Als dit je eerste artikel is, voeg jezelf dan toe als auteur:
       "link": "https://jouw-website.nl"
     }
     ```
-3.  **Voeg een foto toe**: Plaats je profielfoto in de map `public/images/authors/`. Zorg dat de naam in de JSON-file (`image`) exact overeenkomt met het bestandspad.
+
+3. **Voeg een foto toe**: Plaats je profielfoto in de map `public/images/authors/`. Zorg dat de naam in de JSON-file (`image`) exact overeenkomt met het bestandspad.
 
 ## Afbeeldingen gebruiken
 
@@ -60,20 +62,24 @@ Als je de website lokaal wilt draaien om je wijzigingen te zien:
 
 Als je Docker hebt geïnstalleerd, kun je de development omgeving draaien zonder lokaal Node.js te installeren:
 
-1.  **Bouw de image**: 
+1. **Bouw de image**:
+
     ```bash
     docker build -t codeblog-dev -f Dockerfile.dev .
     ```
-2.  **Start de container**:
+
+2. **Start de container**:
+
     ```bash
     docker run -it --rm -p 3000:3000 -v ${PWD}:/app codeblog-dev
     ```
+
     *Op Windows (PowerShell) gebruik je `${PWD}`, op Linux/Mac gebruik je `$(pwd)`.*
 
 De website is daarna bereikbaar op `http://localhost:3000`. Wijzigingen die je lokaal maakt, worden direct doorgevoerd in de container dankzij het 'volume' (`-v`).
 
-
 ### Handmatig
+
 1. Installeer afhankelijkheden: `npm install`
 2. Start de development server: `npm run dev`
 3. Ga naar `http://localhost:3000`

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ We welcome contributions! To keep this README clean, all instructions on how to 
 ## Getting Started
 
 ### Manual Setup
+
 ```bash
 # Install dependencies
 npm install
@@ -38,6 +39,7 @@ npm run build
 ```
 
 ### Using Docker
+
 If you have Docker installed, you can run the development environment without installing Node.js locally:
 
 ```bash

--- a/content/blog/welkom.md
+++ b/content/blog/welkom.md
@@ -17,10 +17,10 @@ Het idee voor dit platform ontstond toen ik in Amerika was. Ik zat in een groep 
 ## Wat kun je hier verwachten?
 
 Op deze blog zullen je regelmatig artikelen zien verschijnen over:
+
 - Microsoft tech zoals Azure en .NET.
 - Moderne webontwikkeling met frameworks zoals Nuxt en Vue.
 - Tips en tricks voor efficiënter programmeren.
 - Persoonlijke ervaringen en lessen uit de praktijk.
 
 Omdat dit platform open source is, kan iedereen die wilt aan dit blog platform meewerken. Blijf kijken voor toekomstige posts!
-

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "@playwright/test": "^1.59.1",
         "@types/node": "^25.6.0",
         "eslint": "^9.39.4",
+        "markdownlint-cli": "^0.48.0",
         "prettier": "^3.5.2"
       }
     },
@@ -6188,6 +6189,13 @@
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/katex": {
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@types/katex/-/katex-0.16.8.tgz",
+      "integrity": "sha512-trgaNyfU+Xh2Tc+ABIb44a5AYUpicB3uwirOioeOkNPPbmgRNtcWyDeeFRzjPZENO9Vq8gvVqfhaaXWLlevVwg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/linkify-it": {
@@ -12770,6 +12778,50 @@
         "node": ">=6"
       }
     },
+    "node_modules/jsonc-parser": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
+      "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jsonpointer": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-5.0.1.tgz",
+      "integrity": "sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/katex": {
+      "version": "0.16.45",
+      "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.45.tgz",
+      "integrity": "sha512-pQpZbdBu7wCTmQUh7ufPmLr0pFoObnGUoL/yhtwJDgmmQpbkg/0HSVti25Fu4rmd1oCR6NGWe9vqTWuWv3GcNA==",
+      "dev": true,
+      "funding": [
+        "https://opencollective.com/katex",
+        "https://github.com/sponsors/katex"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^8.3.0"
+      },
+      "bin": {
+        "katex": "cli.js"
+      }
+    },
+    "node_modules/katex/node_modules/commander": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -13865,6 +13917,84 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/markdownlint": {
+      "version": "0.40.0",
+      "resolved": "https://registry.npmjs.org/markdownlint/-/markdownlint-0.40.0.tgz",
+      "integrity": "sha512-UKybllYNheWac61Ia7T6fzuQNDZimFIpCg2w6hHjgV1Qu0w1TV0LlSgryUGzM0bkKQCBhy2FDhEELB73Kb0kAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "micromark": "4.0.2",
+        "micromark-core-commonmark": "2.0.3",
+        "micromark-extension-directive": "4.0.0",
+        "micromark-extension-gfm-autolink-literal": "2.1.0",
+        "micromark-extension-gfm-footnote": "2.1.0",
+        "micromark-extension-gfm-table": "2.1.1",
+        "micromark-extension-math": "3.1.0",
+        "micromark-util-types": "2.0.2",
+        "string-width": "8.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/DavidAnson"
+      }
+    },
+    "node_modules/markdownlint-cli": {
+      "version": "0.48.0",
+      "resolved": "https://registry.npmjs.org/markdownlint-cli/-/markdownlint-cli-0.48.0.tgz",
+      "integrity": "sha512-NkZQNu2E0Q5qLEEHwWj674eYISTLD4jMHkBzDobujXd1kv+yCxi8jOaD/rZoQNW1FBBMMGQpuW5So8B51N/e0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "commander": "~14.0.3",
+        "deep-extend": "~0.6.0",
+        "ignore": "~7.0.5",
+        "js-yaml": "~4.1.1",
+        "jsonc-parser": "~3.3.1",
+        "jsonpointer": "~5.0.1",
+        "markdown-it": "~14.1.1",
+        "markdownlint": "~0.40.0",
+        "minimatch": "~10.2.4",
+        "run-con": "~1.3.2",
+        "smol-toml": "~1.6.0",
+        "tinyglobby": "~0.2.15"
+      },
+      "bin": {
+        "markdownlint": "markdownlint.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/markdownlint-cli/node_modules/commander": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/markdownlint/node_modules/string-width": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.1.0.tgz",
+      "integrity": "sha512-Kxl3KJGb/gxkaUMOjRsQ8IrXiGW75O4E3RPjFIINOVH8AMl2SQ/yWdTzWwF3FevIX9LcMAjJW+GRwAlAbTSXdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.3.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/marked": {
       "version": "17.0.5",
       "resolved": "https://registry.npmjs.org/marked/-/marked-17.0.5.tgz",
@@ -14200,6 +14330,26 @@
         "micromark-util-types": "^2.0.0"
       }
     },
+    "node_modules/micromark-extension-directive": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-directive/-/micromark-extension-directive-4.0.0.tgz",
+      "integrity": "sha512-/C2nqVmXXmiseSSuCdItCMho7ybwwop6RrrRPk0KbOHW21JKoCldC+8rFOaundDoRBUWBnJJcxeA/Kvi34WQXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-factory-whitespace": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "parse-entities": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/micromark-extension-gfm": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-3.0.0.tgz",
@@ -14311,6 +14461,26 @@
       "license": "MIT",
       "dependencies": {
         "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-math": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-math/-/micromark-extension-math-3.1.0.tgz",
+      "integrity": "sha512-lvEqd+fHjATVs+2v/8kg9i5Q0AP2k85H0WUOwpIVvUML8BapsMvh1XAogmQjOCsLpoKRCVQqEkQBB3NhVBcsOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/katex": "^0.16.0",
+        "devlop": "^1.0.0",
+        "katex": "^0.16.0",
         "micromark-factory-space": "^2.0.0",
         "micromark-util-character": "^2.0.0",
         "micromark-util-symbol": "^2.0.0",
@@ -18147,6 +18317,35 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/run-con": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/run-con/-/run-con-1.3.2.tgz",
+      "integrity": "sha512-CcfE+mYiTcKEzg0IqS08+efdnH0oJ3zV0wSUFBNrMHMuxCtXvBCLzCJHatwuXDcu/RlhjTziTo/a1ruQik6/Yg==",
+      "dev": true,
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~4.1.0",
+        "minimist": "^1.2.8",
+        "strip-json-comments": "~3.1.1"
+      },
+      "bin": {
+        "run-con": "cli.js"
+      }
+    },
+    "node_modules/run-con/node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -18568,6 +18767,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=20.0.0"
+      }
+    },
+    "node_modules/smol-toml": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.6.1.tgz",
+      "integrity": "sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/cyyynthia"
       }
     },
     "node_modules/socket.io-client": {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "generate": "nuxt generate",
     "preview": "nuxt preview",
     "lint": "eslint .",
+    "lint:md": "markdownlint \"**/*.{md,mdx}\" --ignore node_modules",
     "format:check": "prettier --check \"**/*.json\"",
     "test": "playwright test",
     "test:ui": "playwright test --ui",
@@ -37,6 +38,7 @@
     "@playwright/test": "^1.59.1",
     "@types/node": "^25.6.0",
     "eslint": "^9.39.4",
+    "markdownlint-cli": "^0.48.0",
     "prettier": "^3.5.2"
   }
 }


### PR DESCRIPTION
### Description

Closes #14

This pull request adds configuration files and scripts for markdown linting. It also includes the setup for a corresponding GitHub Action to automate markdown linting in the CI pipeline. Dependencies for the linter and related tools have been updated to their latest compatible versions.


